### PR TITLE
Update tab-close.coffee

### DIFF
--- a/lib/tab-close.coffee
+++ b/lib/tab-close.coffee
@@ -48,8 +48,7 @@ module.exports =
       return if modifierKey is 'shift' and not keyPressed.shiftKey
       return if modifierKey is 'ctrl' and not keyPressed.ctrlKey
       return if modifierKey is 'alt' and not keyPressed.altKey
-      tabIndex = $('.tab').index($(this))
-      itemToDestroy = atom.workspace.getPaneItems()[tabIndex]
+      itemToDestroy = atom.workspace.getCenter().getActivePaneItem()
       clickedPane = atom.workspace.paneForItem(itemToDestroy)
       clickedPane?.destroyItem(itemToDestroy)
 


### PR DESCRIPTION
TabIndex was off by one starting with atom.io v1.17.2 causing the immediate tab to the right of the current to close. I got the method to getActivePanelItem() from the committed code in atom.io v1.17.2 release. This version had to change all their atom.workspace methods to use .getCenter() to fix some kind of bug. I updated tab-close code and it fixes the off by one issue and seems more reliable then doing tabIndex-1. 